### PR TITLE
Fixing some cursor and other styling for improved UX

### DIFF
--- a/src/formulate.backoffice.ui/styles/lib/form-designer/miscellaneous.scss
+++ b/src/formulate.backoffice.ui/styles/lib/form-designer/miscellaneous.scss
@@ -9,6 +9,7 @@
     display: inline-block;
     margin-right: 10px;
     vertical-align: middle;
+    cursor:pointer;
 }
 
 .formulate-field.collapsed .collapser,
@@ -18,6 +19,7 @@
     -o-transform: rotate(0deg);
     -webkit-transform: rotate(0deg);
     transform: rotate(0deg);
+    cursor:pointer;
 }
 
 .formulate-field.expanded .collapser,
@@ -27,6 +29,7 @@
     -o-transform: rotate(45deg);
     -webkit-transform: rotate(45deg);
     transform: rotate(45deg);
+    cursor:pointer;
 }
 
 .formulate-field .formulate-field-details,
@@ -34,8 +37,8 @@
     max-height: 1000px;
     overflow: hidden;
     transition:
-            max-height 0.25s,
-            opacity 0.25s;
+    	max-height 0.25s,
+    	opacity 0.25s;
 }
 
 .formulate-field.collapsed .formulate-field-details,
@@ -46,7 +49,7 @@
 
 .formulate-field .drag-handle,
 .formulate-handler .drag-handle {
-    cursor: pointer;
+    cursor: move;
     opacity: 0.5;
     margin-right: 5px;
     font-size: 0.8em;
@@ -60,6 +63,7 @@
     vertical-align: middle;
     font-size: 1.2em;
     text-shadow: 2px 2px $red-dark;
+    cursor:pointer;
 }
 
 .formulate-field .type-identifier,

--- a/src/formulate.backoffice.ui/styles/lib/form-designer/miscellaneous.scss
+++ b/src/formulate.backoffice.ui/styles/lib/form-designer/miscellaneous.scss
@@ -37,8 +37,8 @@
     max-height: 1000px;
     overflow: hidden;
     transition:
-    	max-height 0.25s,
-    	opacity 0.25s;
+        max-height 0.25s,
+        opacity 0.25s;
 }
 
 .formulate-field.collapsed .formulate-field-details,

--- a/src/formulate.backoffice.ui/styles/lib/layout-designer.scss
+++ b/src/formulate.backoffice.ui/styles/lib/layout-designer.scss
@@ -14,7 +14,7 @@
 }
 
 .formulate-cell-field.ui-sortable-handle {
-	cursor:move;
+    cursor:move;
 }
 
 .formulate-cell.editing-rows {
@@ -82,8 +82,6 @@
     font-weight: bold;
     font-size: 18px;
     transition: background-color 0.25s;
-    text-decoration:underline;
-
     &:hover {
         background-color: $green;
     }

--- a/src/formulate.backoffice.ui/styles/lib/layout-designer.scss
+++ b/src/formulate.backoffice.ui/styles/lib/layout-designer.scss
@@ -13,6 +13,10 @@
     margin: 3px;
 }
 
+.formulate-cell-field.ui-sortable-handle {
+	cursor:move;
+}
+
 .formulate-cell.editing-rows {
     background-color: $white-dark;
     border-color: transparent;
@@ -78,6 +82,7 @@
     font-weight: bold;
     font-size: 18px;
     transition: background-color 0.25s;
+    text-decoration:underline;
 
     &:hover {
         background-color: $green;


### PR DESCRIPTION
https://github.com/rhythmagency/formulate/issues/80
Left in underline style for "Click to add a row" because I spent ages trying to figure out how to add a row after "clicking" to split columns. The "button" looked like a heading integrated into the frame. It did not look like a button until you (knowingly) hovered over it.