### PR TITLE
Allow for source property data to be pre-deserialized

### DIFF
--- a/src/formulate.app/Converters/ConfiguredFormConverter.cs
+++ b/src/formulate.app/Converters/ConfiguredFormConverter.cs
@@ -73,11 +73,17 @@
         /// </returns>
         public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
         {
-            var strSource = source as string;
-            strSource = string.IsNullOrWhiteSpace(strSource)
-                ? "{id:null}"
-                : strSource;
-            var deserialized = JsonHelper.Deserialize<dynamic>(strSource);
+            dynamic deserialized = source;
+            if (source.GetType() == typeof(string))
+            {
+                var strSource = source as string;
+                strSource = string.IsNullOrWhiteSpace(strSource)
+                    ? "{id:null}"
+                    : strSource;
+
+                deserialized = JsonHelper.Deserialize<dynamic>(strSource);
+            }
+
             var id = deserialized.id.Value as string;
             var guid = string.IsNullOrWhiteSpace(id) ? null : GuidHelper.GetGuid(id) as Guid?;
             var conForm = guid.HasValue ? ConfiguredForms.Retrieve(guid.Value) : null;


### PR DESCRIPTION
There is an issue using Formulate with Umbraco grid and Leblender where the property data is already JSON deserialized and casting it to a string loses the data, this small change checks if it's necessary to deserialize before proceeding.