### PR TITLE
Feature/148 Ensure Save button states during data processing.

### DIFF
--- a/src/formulate.app/Directives/configuredFormDesigner/designer.html
+++ b/src/formulate.app/Directives/configuredFormDesigner/designer.html
@@ -72,6 +72,7 @@
                     <umb-button alias="save"
                                 type="submit"
                                 button-style="success"
+                                state="saveButtonState"
                                 shortcut="ctrl+s"
                                 label-key="formulate-buttons_Save"
                                 disabled="!canSave()">

--- a/src/formulate.app/Directives/configuredFormDesigner/designer.js
+++ b/src/formulate.app/Directives/configuredFormDesigner/designer.js
@@ -37,6 +37,7 @@ function controller($scope, $routeParams, $route, formulateTrees,
     };
 
     // Set scope variables.
+    $scope.saveButtonState = "init";
     $scope.isNew = isNew;
     $scope.info = {
         conFormName: null
@@ -110,6 +111,9 @@ function getSaveConfiguredForm(services) {
         var $scope = services.$scope;
         var parentId = getParentId($scope);
 
+        // Update button state.
+        $scope.saveButtonState = "busy";
+
         // Get configured form data.
         var conFormData = {
             parentId: parentId,
@@ -126,6 +130,9 @@ function getSaveConfiguredForm(services) {
                 // Configured form is no longer new.
                 var isNew = $scope.isNew;
                 $scope.isNew = false;
+
+                // Update button state.
+                $scope.saveButtonState = "success";
 
                 // Prevent "discard" notification.
                 $scope.formulateConfiguredFormDesigner.$dirty = false;

--- a/src/formulate.app/Directives/dataValueDesigner/designer.html
+++ b/src/formulate.app/Directives/dataValueDesigner/designer.html
@@ -30,6 +30,7 @@
                     <umb-button alias="save"
                                 type="submit"
                                 button-style="success"
+                                state="saveButtonState"
                                 shortcut="ctrl+s"
                                 label-key="formulate-buttons_Save"
                                 disabled="!canSave()">

--- a/src/formulate.app/Directives/dataValueDesigner/designer.js
+++ b/src/formulate.app/Directives/dataValueDesigner/designer.js
@@ -30,6 +30,7 @@ function controller($scope, $routeParams, $route, formulateTrees,
     };
 
     // Set scope variables.
+    $scope.saveButtonState = "init";
     $scope.dataValueId = id;
     $scope.info = {
         dataValueName: null,
@@ -81,6 +82,9 @@ function getSaveDataValue(services) {
         var $scope = services.$scope;
         var parentId = getParentId($scope);
 
+        // Update button state.
+        $scope.saveButtonState = "busy";
+
         // Get data value data.
         var dataValueData = {
             parentId: parentId,
@@ -98,6 +102,9 @@ function getSaveDataValue(services) {
                 // Data value is no longer new.
                 var isNew = $scope.isNew;
                 $scope.isNew = false;
+
+                // Update button state.
+                $scope.saveButtonState = "success";
 
                 // Redirect or reload page.
                 if (isNew) {

--- a/src/formulate.app/Directives/folderDesigner/designer.html
+++ b/src/formulate.app/Directives/folderDesigner/designer.html
@@ -31,6 +31,7 @@
                     <umb-button alias="save"
                                 type="submit"
                                 button-style="success"
+                                state="saveButtonState"
                                 shortcut="ctrl+s"
                                 label-key="formulate-buttons_Save"
                                 disabled="!canSave()">

--- a/src/formulate.app/Directives/folderDesigner/designer.js
+++ b/src/formulate.app/Directives/folderDesigner/designer.js
@@ -29,6 +29,7 @@ function controller($scope, $routeParams, $route, formulateTrees,
     };
 
     // Set scope variables.
+    $scope.saveButtonState = "init";
     $scope.folderId = id;
     $scope.info = {
         folderName: null
@@ -75,6 +76,9 @@ function getSaveFolder(services) {
         var $scope = services.$scope;
         var parentId = getParentId($scope);
 
+        // Update button state.
+        $scope.saveButtonState = "busy";
+
         // Get folder data.
         var folderData = {
             parentId: parentId,
@@ -84,7 +88,10 @@ function getSaveFolder(services) {
 
         // Persist folder on server.
         services.formulateFolders.persistFolder(folderData)
-            .then(function() {
+            .then(function () {
+
+                // Update button state.
+                $scope.saveButtonState = "success";
 
                 // Even existing folders reload (e.g., to get new data).
                 services.$route.reload();

--- a/src/formulate.app/Directives/formDesigner/designer.html
+++ b/src/formulate.app/Directives/formDesigner/designer.html
@@ -232,6 +232,7 @@
                     <umb-button alias="save"
                                 type="submit"
                                 button-style="success"
+                                state="saveButtonState"
                                 shortcut="ctrl+s"
                                 label-key="formulate-buttons_Save">
                     </umb-button>

--- a/src/formulate.app/Directives/formDesigner/designer.js
+++ b/src/formulate.app/Directives/formDesigner/designer.js
@@ -186,7 +186,7 @@ function getSaveForm(services) {
         var handlers = $scope.handlers;
         var parentId = getParentId($scope);
 
-        // Update scope.
+        // Update button state.
         $scope.saveButtonState = "busy";
 
         // Get form data.
@@ -206,7 +206,7 @@ function getSaveForm(services) {
                 // Variables.
                 var isNew = $scope.isNew;
 
-                // Update scope.
+                // Update button state.
                 $scope.saveButtonState = "success";
 
                 // Prevent "discard" notification.

--- a/src/formulate.app/Directives/formDesigner/designer.js
+++ b/src/formulate.app/Directives/formDesigner/designer.js
@@ -37,6 +37,7 @@ function controller($scope, $routeParams, $route, formulateTrees,
     };
 
     // Set scope variables.
+    $scope.saveButtonState = "init";
     $scope.isNew = isNew;
     $scope.info = {
         formName: null,
@@ -185,6 +186,9 @@ function getSaveForm(services) {
         var handlers = $scope.handlers;
         var parentId = getParentId($scope);
 
+        // Update scope.
+        $scope.saveButtonState = "busy";
+
         // Get form data.
         var formData = {
             parentId: parentId,
@@ -201,6 +205,9 @@ function getSaveForm(services) {
 
                 // Variables.
                 var isNew = $scope.isNew;
+
+                // Update scope.
+                $scope.saveButtonState = "success";
 
                 // Prevent "discard" notification.
                 $scope.formulateFormDesigner.$dirty = false;

--- a/src/formulate.app/Directives/layoutDesigner/designer.html
+++ b/src/formulate.app/Directives/layoutDesigner/designer.html
@@ -27,6 +27,7 @@
                     <umb-button alias="save"
                                 type="submit"
                                 button-style="success"
+                                state="saveButtonState"
                                 shortcut="ctrl+s"
                                 label-key="formulate-buttons_Save"
                                 disabled="!canSave()">

--- a/src/formulate.app/Directives/layoutDesigner/designer.js
+++ b/src/formulate.app/Directives/layoutDesigner/designer.js
@@ -29,6 +29,7 @@ function controller($scope, $routeParams, $route, formulateTrees,
     };
 
     // Set scope variables.
+    $scope.saveButtonState = "init";
     $scope.layoutId = id;
     $scope.info = {
         layoutName: null,
@@ -80,6 +81,9 @@ function getSaveLayout(services) {
         var $scope = services.$scope;
         var parentId = getParentId($scope);
 
+        // Update button state.
+        $scope.saveButtonState = "busy";
+
         // Get layout data.
         var layoutData = {
             parentId: parentId,
@@ -97,6 +101,9 @@ function getSaveLayout(services) {
                 // Layout is no longer new.
                 var isNew = $scope.isNew;
                 $scope.isNew = false;
+
+                // Update button state.
+                $scope.saveButtonState = "success";
 
                 // Redirect or reload page.
                 if (isNew) {

--- a/src/formulate.app/Directives/validationDesigner/designer.html
+++ b/src/formulate.app/Directives/validationDesigner/designer.html
@@ -29,6 +29,7 @@
                     <umb-button alias="save"
                                 type="submit"
                                 button-style="success"
+                                state="saveButtonState"
                                 shortcut="ctrl+s"
                                 label-key="formulate-buttons_Save"
                                 disabled="!canSave()">

--- a/src/formulate.app/Directives/validationDesigner/designer.js
+++ b/src/formulate.app/Directives/validationDesigner/designer.js
@@ -29,6 +29,7 @@ function controller($scope, $routeParams, $route, formulateValidations,
     };
 
     // Set scope variables.
+    $scope.saveButtonState = "init";
     $scope.validationId = id;
     $scope.info = {
         validationName: null,
@@ -79,6 +80,9 @@ function getSaveValidation(services) {
         var $scope = services.$scope;
         var parentId = getParentId($scope);
 
+        // Update button state.
+        $scope.saveButtonState = "busy";
+
         // Get validation data.
         var validationData = {
             parentId: parentId,
@@ -96,6 +100,9 @@ function getSaveValidation(services) {
                 // Validation is no longer new.
                 var isNew = $scope.isNew;
                 $scope.isNew = false;
+
+                // Update button state.
+                $scope.saveButtonState = "success";
 
                 // Redirect or reload page.
                 if (isNew) {


### PR DESCRIPTION
PR for issue #148. This essentially applies the busy state (aka "spinning button") to save buttons in designers while they're processing data. Upon success the button has the success state applied to it before reverting to the init state, which Umbraco does automatically without any intervention.

Eventually we should expand this to set error state if the save was unsuccessful. We do not currently support this outcome.