### PR TITLE
Fixes 187. Validation Regex was not rendering the regex pattern.

### DIFF
--- a/src/formulate.app/Validations/Kinds/Regex/ValidationRegexConfiguration.cs
+++ b/src/formulate.app/Validations/Kinds/Regex/ValidationRegexConfiguration.cs
@@ -1,5 +1,7 @@
 ﻿namespace formulate.app.Validations.Kinds.Regex
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// Configuration used by <see cref="ValidationRegex"/>.
     /// </summary>
@@ -10,6 +12,7 @@
         /// <summary>
         /// Gets or sets the regular expression pattern.
         /// </summary>
+        [JsonProperty("regex")]
         public string Pattern { get; set; }
 
         /// <summary>


### PR DESCRIPTION
This fixes #187. The solution was to repurpose the "regex" json config property as "Pattern" in the C# file.