### PR TITLE
Fixed line breaks not being used in html emails

### DIFF
--- a/src/formulate.app/Forms/Handlers/Email/EmailHandler.cs
+++ b/src/formulate.app/Forms/Handlers/Email/EmailHandler.cs
@@ -1,4 +1,4 @@
-﻿namespace formulate.app.Forms.Handlers.Email
+namespace formulate.app.Forms.Handlers.Email
 {
 
     // Namespaces.
@@ -452,7 +452,10 @@
             if (isHtml)
             {
                 baseMessage = WebUtility.HtmlEncode(baseMessage);
-                lines = lines.Select(x => WebUtility.HtmlEncode(x)).ToList();
+
+                //Add line breaks in after encoding.
+                lines = lines.Select(x => WebUtility.HtmlEncode(x)
+                .Replace(Environment.NewLine, Environment.NewLine + "<br>" + Environment.NewLine)).ToList();
             }
 
             // Return message.

--- a/src/formulate.app/Forms/Handlers/Email/EmailHandler.cs
+++ b/src/formulate.app/Forms/Handlers/Email/EmailHandler.cs
@@ -14,6 +14,7 @@ namespace formulate.app.Forms.Handlers.Email
     using System.Net;
     using System.Net.Mail;
     using System.Net.Mime;
+    using System.Text.RegularExpressions;
     using Umbraco.Core;
 
     /// <summary>
@@ -93,6 +94,11 @@ namespace formulate.app.Forms.Handlers.Email
         /// Gets or sets the config.
         /// </summary>
         private IConfigurationManager Config { get; set; }
+
+        /// <summary>
+        /// Precompiled regex for finding line breaks.
+        /// </summary>
+        private static Regex LineBreakRegex = new Regex(@"(\r\n|\r(?!\n)|(?<!\r)\n)", RegexOptions.Compiled);
 
         #endregion
 
@@ -453,9 +459,8 @@ namespace formulate.app.Forms.Handlers.Email
             {
                 baseMessage = WebUtility.HtmlEncode(baseMessage);
 
-                //Add line breaks in after encoding.
-                lines = lines.Select(x => WebUtility.HtmlEncode(x)
-                .Replace(Environment.NewLine, Environment.NewLine + "<br>" + Environment.NewLine)).ToList();
+                lines = lines.Select(x => LineBreakRegex.Replace(WebUtility.HtmlEncode(x),
+                  Environment.NewLine + "<br>" + Environment.NewLine)).ToList();
             }
 
             // Return message.

--- a/src/formulate.meta/Constants.cs
+++ b/src/formulate.meta/Constants.cs
@@ -17,7 +17,7 @@
         /// Do not reformat this code. A grunt task reads this
         /// version number with a regular expression.
         /// </remarks>
-        public const string Version = "3.5.2";
+        public const string Version = "3.5.3";
 
 
         /// <summary>

--- a/src/formulate.meta/Constants.cs
+++ b/src/formulate.meta/Constants.cs
@@ -17,7 +17,7 @@
         /// Do not reformat this code. A grunt task reads this
         /// version number with a regular expression.
         /// </remarks>
-        public const string Version = "3.5.3";
+        public const string Version = "3.5.2";
 
 
         /// <summary>


### PR DESCRIPTION
_Warning: I have never done a pull request before, so something could be wrong with this!_

Fixed line breaks not being used in html emails (issue #214).

I initially tried to change the text areas formatValue method, but any html gets formatted out later, so the fix needs to be after that point. It should also only affect html emails, and does nothing to change the storage of the text.

I've done a bit of testing with the fix:

![Formulate Test 1](https://user-images.githubusercontent.com/3150585/175079612-32117d9f-9331-4ed2-9330-34992281b7e4.png)
![Formulate Test 2](https://user-images.githubusercontent.com/3150585/175079588-e7db921a-18ca-4c90-bf7a-285019a25e2e.png)
![Formulate Test 3](https://user-images.githubusercontent.com/3150585/175079596-0f5c49c4-546b-4c58-895f-e31542b3a32f.png)


